### PR TITLE
Add gitignore, new allowed args, add to tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+data
+venv
+build
+install

--- a/examples/read_args.hpp
+++ b/examples/read_args.hpp
@@ -29,6 +29,7 @@ inline boost::program_options::options_description setup_args()
         ("internal-diving", boost::program_options::value<int>(), "set internal diving")
         ("discrepancy-limit", boost::program_options::value<int>(), "set discrepancy limit")
         ("automatic-stop", boost::program_options::value<bool>(), "set automatic stop")
+        ("dummy-coefficient-value", boost::program_options::value<float>(), "Set dummy coefficient value in the column generation master problem")
         ;
     return desc;
 }
@@ -72,6 +73,8 @@ inline void read_args(
     parameters.column_pool = column_pool;
     if (vm.count("internal-diving"))
         parameters.internal_diving = vm["internal-diving"].as<int>();
+    if (vm.count("dummy-coefficient-value"))
+        parameters.dummy_column_objective_coefficient = vm["dummy-coefficient-value"].as<float>();
 }
 
 inline void write_output(

--- a/examples/read_args.hpp
+++ b/examples/read_args.hpp
@@ -29,7 +29,7 @@ inline boost::program_options::options_description setup_args()
         ("internal-diving", boost::program_options::value<int>(), "set internal diving")
         ("discrepancy-limit", boost::program_options::value<int>(), "set discrepancy limit")
         ("automatic-stop", boost::program_options::value<bool>(), "set automatic stop")
-        ("dummy-coefficient-value", boost::program_options::value<float>(), "Set dummy coefficient value in the column generation master problem")
+        ("dummy-column-objective-coefficient", boost::program_options::value<Value>(), "Set dummy coefficient value in the column generation master problem")
         ;
     return desc;
 }
@@ -73,8 +73,8 @@ inline void read_args(
     parameters.column_pool = column_pool;
     if (vm.count("internal-diving"))
         parameters.internal_diving = vm["internal-diving"].as<int>();
-    if (vm.count("dummy-coefficient-value"))
-        parameters.dummy_column_objective_coefficient = vm["dummy-coefficient-value"].as<float>();
+    if (vm.count("dummy-column-objective-coefficient"))
+        parameters.dummy_column_objective_coefficient = vm["dummy-column-objective-coefficient"].as<Value>();
 }
 
 inline void write_output(

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -142,13 +142,6 @@ if args.tests is None or "cutting-stock" in args.tests:
                 instance + ".json")
         if not os.path.exists(os.path.dirname(json_output_path)):
             os.makedirs(os.path.dirname(json_output_path))
-        # Read the second line of the instance file to obtain the capacity of the cutting stock
-        # problem. This can be used to set the dummy coefficient value in the column generation
-        # master problem which is set to 1 otherwise.
-        with open(instance_path, 'r') as f:
-            f.readline()
-            capacity = float(f.readline().strip())
-
         command = (
                 main
                 + "  --verbosity-level 1"
@@ -156,8 +149,7 @@ if args.tests is None or "cutting-stock" in args.tests:
                 + " --format \"" + instance_format + "\""
                 + "  --algorithm greedy"
                 + " --internal-diving 1"
-                + "  --output \"" + json_output_path + "\""
-                + f" --dummy-coefficient-value {capacity}")
+                + "  --output \"" + json_output_path + "\"")
         print(command)
         status = os.system(command)
         if status != 0:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -142,6 +142,13 @@ if args.tests is None or "cutting-stock" in args.tests:
                 instance + ".json")
         if not os.path.exists(os.path.dirname(json_output_path)):
             os.makedirs(os.path.dirname(json_output_path))
+        # Read the second line of the instance file to obtain the capacity of the cutting stock
+        # problem. This can be used to set the dummy coefficient value in the column generation
+        # master problem which is set to 1 otherwise.
+        with open(instance_path, 'r') as f:
+            f.readline()
+            capacity = float(f.readline().strip())
+
         command = (
                 main
                 + "  --verbosity-level 1"
@@ -149,7 +156,8 @@ if args.tests is None or "cutting-stock" in args.tests:
                 + " --format \"" + instance_format + "\""
                 + "  --algorithm greedy"
                 + " --internal-diving 1"
-                + "  --output \"" + json_output_path + "\"")
+                + "  --output \"" + json_output_path + "\""
+                + f" --dummy-coefficient-value {capacity}")
         print(command)
         status = os.system(command)
         if status != 0:


### PR DESCRIPTION
Resolves https://github.com/fontanf/columngenerationsolver/issues/33

Adds `dummy-coefficient-value` to the command line parameters.

This is so that no src files need changing if users want to add external examples without touching any internal code (alternatively changes would need to be made to all algorithms in src making it less modular).

Standard files are also added to a .gitignore.

