### PR TITLE
Add inline-dependencies for python files

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "gdown",
+# ]
+# ///
 import gdown
 import os
 import pathlib

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,3 +1,8 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
 import argparse
 import sys
 import os
@@ -255,3 +260,4 @@ if args.tests is None or "vehicle-routing-with-time-windows" in args.tests:
         print()
     print()
     print()
+


### PR DESCRIPTION
This follows [PEP 723](https://peps.python.org/pep-0723/) for adding the python-dependencies into the script-files themselves. The only dependency at the moment seems to be `gdown`.

With this added, the files can comfortably be executed, e.g. via [uv](https://docs.astral.sh/uv): `uv run scripts/download_data.py`, which installs dependencies as required.

I produced the changes in this PR by running `uv init --script scripts/run_tests.py` and `uv add gdown --script scripts/run_tests.py`.