### PR TITLE
Fix column_highest_cost residual bounds and split infeasibility signal

### DIFF
--- a/include/columngenerationsolver/algorithms/column_generation.hpp
+++ b/include/columngenerationsolver/algorithms/column_generation.hpp
@@ -17,7 +17,25 @@ struct ColumnGenerationOutput: Output
     /** Value of the relaxation solution (with dummy columns). */
     double relaxation_solution_value = 0.0;
 
-    bool feasible = false;
+    /**
+     * 'true' iff column generation converged to a relaxation solution
+     * containing no dummy column (i.e. 'relaxation_solution' is feasible
+     * for the constraints).
+     */
+    bool relaxation_solution_is_feasible = false;
+
+    /**
+     * 'true' iff column generation stopped because the dummy column
+     * objective coefficient grew far larger than the cost of any generated
+     * column, which is taken as a (heuristic, not formally proven) signal
+     * that this node/branch has no feasible solution.
+     *
+     * Note this is distinct from column generation simply running out of
+     * time or iterations: in that case both 'relaxation_solution_is_feasible'
+     * and 'is_proven_infeasible' are 'false', meaning the result is
+     * inconclusive rather than infeasible.
+     */
+    bool is_proven_infeasible = false;
 
     /** Number of columns in the linear subproblem. */
     ColIdx number_of_columns_in_linear_subproblem = 0;

--- a/include/columngenerationsolver/algorithms/greedy.hpp
+++ b/include/columngenerationsolver/algorithms/greedy.hpp
@@ -38,6 +38,12 @@ struct GreedyOutput: Output
 
     Counter number_of_nodes = 0;
 
+    /**
+     * 'true' iff the root node relaxation was proven infeasible by column
+     * generation (see 'ColumnGenerationOutput::is_proven_infeasible').
+     */
+    bool is_proven_infeasible = false;
+
 
     virtual int format_width() const override { return 31; }
 
@@ -47,6 +53,7 @@ struct GreedyOutput: Output
         int width = format_width();
         os
             << std::setw(width) << std::left << "Number of nodes: " << number_of_nodes << std::endl
+            << std::setw(width) << std::left << "Proven infeasible: " << is_proven_infeasible << std::endl
             ;
     }
 
@@ -55,6 +62,7 @@ struct GreedyOutput: Output
         nlohmann::json json = Output::to_json();
         json.merge_patch({
                 {"NumberOfNodes", number_of_nodes},
+                {"IsProvenInfeasible", is_proven_infeasible},
                 });
         return json;
     }

--- a/include/columngenerationsolver/algorithms/limited_discrepancy_search.hpp
+++ b/include/columngenerationsolver/algorithms/limited_discrepancy_search.hpp
@@ -59,6 +59,12 @@ struct LimitedDiscrepancySearchOutput: Output
 
     Value maximum_discrepancy = -1;
 
+    /**
+     * 'true' iff the root node relaxation was proven infeasible by column
+     * generation (see 'ColumnGenerationOutput::is_proven_infeasible').
+     */
+    bool is_proven_infeasible = false;
+
 
     virtual int format_width() const override { return 30; }
 
@@ -70,6 +76,7 @@ struct LimitedDiscrepancySearchOutput: Output
             << std::setw(width) << std::left << "Number of nodes: " << number_of_nodes << std::endl
             << std::setw(width) << std::left << "Maximum depth: " << maximum_depth << std::endl
             << std::setw(width) << std::left << "Maximum discrepancy: " << maximum_discrepancy << std::endl
+            << std::setw(width) << std::left << "Proven infeasible: " << is_proven_infeasible << std::endl
             ;
     }
 
@@ -80,6 +87,7 @@ struct LimitedDiscrepancySearchOutput: Output
                 {"NumberOfNodes", number_of_nodes},
                 {"MaximumDepth", maximum_depth},
                 {"MaximumDiscrepancy", maximum_discrepancy},
+                {"IsProvenInfeasible", is_proven_infeasible},
                 });
         return json;
     }

--- a/src/algorithms/column_generation.cpp
+++ b/src/algorithms/column_generation.cpp
@@ -127,11 +127,22 @@ const ColumnGenerationOutput columngenerationsolver::column_generation(
 
         Value value_max = std::numeric_limits<Value>::infinity();
         for (const LinearTerm& element: column->elements) {
+            // Use the residual row bounds (after subtracting the
+            // contribution of already fixed columns) rather than the
+            // original model bounds, otherwise the estimate can be wildly
+            // overestimated once columns have been fixed.
+            RowIdx new_row_id = new_row_indices[element.row];
+            Value row_lower_bound = (new_row_id >= 0)?
+                new_row_lower_bounds[new_row_id]:
+                model.rows[element.row].lower_bound;
+            Value row_upper_bound = (new_row_id >= 0)?
+                new_row_upper_bounds[new_row_id]:
+                model.rows[element.row].upper_bound;
             if (element.coefficient > 0) {
-                Value v = model.rows[element.row].upper_bound / element.coefficient;
+                Value v = row_upper_bound / element.coefficient;
                 value_max = (std::min)(value_max, v);
             } else {
-                Value v = model.rows[element.row].lower_bound / element.coefficient;
+                Value v = row_lower_bound / element.coefficient;
                 value_max = (std::min)(value_max, v);
             }
         }
@@ -701,11 +712,23 @@ const ColumnGenerationOutput columngenerationsolver::column_generation(
                         column_pool.insert(column);
                         Value value_max = std::numeric_limits<Value>::infinity();
                         for (const LinearTerm& element: column->elements) {
+                            // Use the residual row bounds (after subtracting
+                            // the contribution of already fixed columns)
+                            // rather than the original model bounds,
+                            // otherwise the estimate can be wildly
+                            // overestimated once columns have been fixed.
+                            RowIdx new_row_id = new_row_indices[element.row];
+                            Value row_lower_bound = (new_row_id >= 0)?
+                                new_row_lower_bounds[new_row_id]:
+                                model.rows[element.row].lower_bound;
+                            Value row_upper_bound = (new_row_id >= 0)?
+                                new_row_upper_bounds[new_row_id]:
+                                model.rows[element.row].upper_bound;
                             if (element.coefficient > 0) {
-                                Value v = model.rows[element.row].upper_bound / element.coefficient;
+                                Value v = row_upper_bound / element.coefficient;
                                 value_max = (std::min)(value_max, v);
                             } else {
-                                Value v = model.rows[element.row].lower_bound / element.coefficient;
+                                Value v = row_lower_bound / element.coefficient;
                                 value_max = (std::min)(value_max, v);
                             }
                         }
@@ -898,7 +921,7 @@ const ColumnGenerationOutput columngenerationsolver::column_generation(
 
         // If the final solution doesn't contain any dummy column, then stop.
         if (!has_dummy_column) {
-            output.feasible = true;
+            output.relaxation_solution_is_feasible = true;
             //std::cout << "feasible" << std::endl;
             output.relaxation_solution = solution_builder.build();
             if (!output.relaxation_solution.feasible_relaxation()) {
@@ -917,6 +940,7 @@ const ColumnGenerationOutput columngenerationsolver::column_generation(
                 && std::abs(output.dummy_column_objective_coefficient)
                 > 100 * column_highest_cost) {
             //std::cout << "infeasible" << std::endl;
+            output.is_proven_infeasible = true;
             output.relaxation_solution = solution_builder.build();
             break;
         }

--- a/src/algorithms/greedy.cpp
+++ b/src/algorithms/greedy.cpp
@@ -73,6 +73,8 @@ const GreedyOutput columngenerationsolver::greedy(
         output.time_pricing += cg_output.time_pricing;
         output.dummy_column_objective_coefficient = cg_output.dummy_column_objective_coefficient;
         output.number_of_column_generation_iterations += cg_output.number_of_column_generation_iterations;
+        if (output.number_of_nodes == 0)
+            output.is_proven_infeasible = cg_output.is_proven_infeasible;
         output.columns.insert(
                 output.columns.end(),
                 cg_output.columns.begin(),
@@ -90,7 +92,7 @@ const GreedyOutput columngenerationsolver::greedy(
         if (parameters.timer.needs_to_end())
             break;
 
-        if (!cg_output.feasible)
+        if (!cg_output.relaxation_solution_is_feasible)
             break;
 
         // Update bound.

--- a/src/algorithms/limited_discrepancy_search.cpp
+++ b/src/algorithms/limited_discrepancy_search.cpp
@@ -241,8 +241,9 @@ const LimitedDiscrepancySearchOutput columngenerationsolver::limited_discrepancy
                 algorithm_formatter.print_header();
                 algorithm_formatter.update_bound(cg_output.bound);
                 output.relaxation_solution = cg_output.relaxation_solution;
+                output.is_proven_infeasible = cg_output.is_proven_infeasible;
             }
-            if (!cg_output.feasible) {
+            if (!cg_output.relaxation_solution_is_feasible) {
                 //std::cout << "no solution" << std::endl;
                 continue;
             }


### PR DESCRIPTION
column_highest_cost estimated a column's maximum value against the original row bounds instead of the residual bounds after already-fixed columns, overestimating it and making the dummy-column infeasibility threshold too conservative once columns are fixed during branching.

Also split ColumnGenerationOutput::feasible into
relaxation_solution_is_feasible and is_proven_infeasible so callers can distinguish "no feasible relaxation found" from "budget exhausted" (inconclusive) versus the dummy-column threshold actually triggering. Propagated to GreedyOutput and LimitedDiscrepancySearchOutput.