### PR TITLE
Fix zero-cost infeasibility detection and signal it via an infinite bound

### DIFF
--- a/include/columngenerationsolver/algorithms/column_generation.hpp
+++ b/include/columngenerationsolver/algorithms/column_generation.hpp
@@ -21,21 +21,18 @@ struct ColumnGenerationOutput: Output
      * 'true' iff column generation converged to a relaxation solution
      * containing no dummy column (i.e. 'relaxation_solution' is feasible
      * for the constraints).
+     *
+     * A (heuristic, not formally proven) infeasibility signal is reported
+     * through 'bound' instead of a separate flag: by the standard extended
+     * reals convention, the optimal value of an infeasible problem is +inf
+     * (minimization) or -inf (maximization), so 'bound' reaching that value
+     * means this node/branch has no feasible solution. This is distinct
+     * from column generation simply running out of time or iterations, in
+     * which case 'bound' stays finite and 'relaxation_solution_is_feasible'
+     * is 'false', meaning the result is inconclusive rather than
+     * infeasible.
      */
     bool relaxation_solution_is_feasible = false;
-
-    /**
-     * 'true' iff column generation stopped because the dummy column
-     * objective coefficient grew far larger than the cost of any generated
-     * column, which is taken as a (heuristic, not formally proven) signal
-     * that this node/branch has no feasible solution.
-     *
-     * Note this is distinct from column generation simply running out of
-     * time or iterations: in that case both 'relaxation_solution_is_feasible'
-     * and 'is_proven_infeasible' are 'false', meaning the result is
-     * inconclusive rather than infeasible.
-     */
-    bool is_proven_infeasible = false;
 
     /** Number of columns in the linear subproblem. */
     ColIdx number_of_columns_in_linear_subproblem = 0;

--- a/include/columngenerationsolver/algorithms/greedy.hpp
+++ b/include/columngenerationsolver/algorithms/greedy.hpp
@@ -38,12 +38,6 @@ struct GreedyOutput: Output
 
     Counter number_of_nodes = 0;
 
-    /**
-     * 'true' iff the root node relaxation was proven infeasible by column
-     * generation (see 'ColumnGenerationOutput::is_proven_infeasible').
-     */
-    bool is_proven_infeasible = false;
-
 
     virtual int format_width() const override { return 31; }
 
@@ -53,7 +47,6 @@ struct GreedyOutput: Output
         int width = format_width();
         os
             << std::setw(width) << std::left << "Number of nodes: " << number_of_nodes << std::endl
-            << std::setw(width) << std::left << "Proven infeasible: " << is_proven_infeasible << std::endl
             ;
     }
 
@@ -62,7 +55,6 @@ struct GreedyOutput: Output
         nlohmann::json json = Output::to_json();
         json.merge_patch({
                 {"NumberOfNodes", number_of_nodes},
-                {"IsProvenInfeasible", is_proven_infeasible},
                 });
         return json;
     }

--- a/include/columngenerationsolver/algorithms/limited_discrepancy_search.hpp
+++ b/include/columngenerationsolver/algorithms/limited_discrepancy_search.hpp
@@ -59,12 +59,6 @@ struct LimitedDiscrepancySearchOutput: Output
 
     Value maximum_discrepancy = -1;
 
-    /**
-     * 'true' iff the root node relaxation was proven infeasible by column
-     * generation (see 'ColumnGenerationOutput::is_proven_infeasible').
-     */
-    bool is_proven_infeasible = false;
-
 
     virtual int format_width() const override { return 30; }
 
@@ -76,7 +70,6 @@ struct LimitedDiscrepancySearchOutput: Output
             << std::setw(width) << std::left << "Number of nodes: " << number_of_nodes << std::endl
             << std::setw(width) << std::left << "Maximum depth: " << maximum_depth << std::endl
             << std::setw(width) << std::left << "Maximum discrepancy: " << maximum_discrepancy << std::endl
-            << std::setw(width) << std::left << "Proven infeasible: " << is_proven_infeasible << std::endl
             ;
     }
 
@@ -87,7 +80,6 @@ struct LimitedDiscrepancySearchOutput: Output
                 {"NumberOfNodes", number_of_nodes},
                 {"MaximumDepth", maximum_depth},
                 {"MaximumDiscrepancy", maximum_discrepancy},
-                {"IsProvenInfeasible", is_proven_infeasible},
                 });
         return json;
     }

--- a/include/columngenerationsolver/commons.hpp
+++ b/include/columngenerationsolver/commons.hpp
@@ -805,6 +805,22 @@ struct Output: optimizationtools::Output
                 solution.objective_value());
     }
 
+    /**
+     * String representation of 'bound'. JSON has no representation for
+     * +/-inf (nlohmann::json silently serializes both to 'null', making
+     * them indistinguishable), so 'bound' is exposed to JSON as a string
+     * instead of a raw number, the same way 'solution_value()' already is.
+     * This matters in particular because 'bound' reaching +inf
+     * (minimization) or -inf (maximization) is how infeasibility is
+     * signaled (see 'ColumnGenerationOutput::relaxation_solution_is_feasible').
+     */
+    std::string bound_string() const
+    {
+        std::stringstream ss;
+        ss << bound;
+        return ss.str();
+    }
+
     double absolute_optimality_gap() const
     {
         return optimizationtools::absolute_optimality_gap(
@@ -827,7 +843,7 @@ struct Output: optimizationtools::Output
     {
         return {
             {"Value", solution_value()},
-            {"Bound", bound},
+            {"Bound", bound_string()},
             {"AbsoluteOptimalityGap", absolute_optimality_gap()},
             {"RelativeOptimalityGap", relative_optimality_gap()},
             {"Time", time},

--- a/src/algorithms/column_generation.cpp
+++ b/src/algorithms/column_generation.cpp
@@ -58,7 +58,11 @@ const ColumnGenerationOutput columngenerationsolver::column_generation(
         //    << std::endl;
         if (model.rows[row_id].coefficient_lower_bound >= 0
                 && row_values[row_id] > model.rows[row_id].upper_bound + model.rows[row_id].feasibility_tolerance) {
-            // Infeasible.
+            // Infeasible: the fixed columns alone already violate this row.
+            algorithm_formatter.update_bound(
+                    (model.objective_sense == optimizationtools::ObjectiveDirection::Minimize)?
+                        std::numeric_limits<Value>::infinity():
+                        -std::numeric_limits<Value>::infinity());
             return output;
         }
         if (model.rows[row_id].coefficient_lower_bound >= 0
@@ -936,11 +940,20 @@ const ColumnGenerationOutput columngenerationsolver::column_generation(
         // column objective coefficient is significantly larger than the
         // largest generated column objective coefficient, then we consider the
         // problem infeasible.
-        if (column_highest_cost > 0
-                && std::abs(output.dummy_column_objective_coefficient)
+        // No 'column_highest_cost > 0' guard here: when every column has an
+        // objective coefficient of 0 (a pure feasibility problem),
+        // 'column_highest_cost' is always 0, so the threshold below already
+        // reduces to 'dummy coefficient > 0', which is the correct
+        // condition in that case (the master LP's optimal basis doesn't
+        // depend on the dummy coefficient's magnitude when the real
+        // objective is identically 0, only on whether it's positive).
+        if (std::abs(output.dummy_column_objective_coefficient)
                 > 100 * column_highest_cost) {
             //std::cout << "infeasible" << std::endl;
-            output.is_proven_infeasible = true;
+            algorithm_formatter.update_bound(
+                    (model.objective_sense == optimizationtools::ObjectiveDirection::Minimize)?
+                        std::numeric_limits<Value>::infinity():
+                        -std::numeric_limits<Value>::infinity());
             output.relaxation_solution = solution_builder.build();
             break;
         }

--- a/src/algorithms/greedy.cpp
+++ b/src/algorithms/greedy.cpp
@@ -73,8 +73,6 @@ const GreedyOutput columngenerationsolver::greedy(
         output.time_pricing += cg_output.time_pricing;
         output.dummy_column_objective_coefficient = cg_output.dummy_column_objective_coefficient;
         output.number_of_column_generation_iterations += cg_output.number_of_column_generation_iterations;
-        if (output.number_of_nodes == 0)
-            output.is_proven_infeasible = cg_output.is_proven_infeasible;
         output.columns.insert(
                 output.columns.end(),
                 cg_output.columns.begin(),

--- a/src/algorithms/limited_discrepancy_search.cpp
+++ b/src/algorithms/limited_discrepancy_search.cpp
@@ -239,9 +239,8 @@ const LimitedDiscrepancySearchOutput columngenerationsolver::limited_discrepancy
 
             if (node->depth == 0) {
                 algorithm_formatter.print_header();
-                algorithm_formatter.update_bound(cg_output.bound);
                 output.relaxation_solution = cg_output.relaxation_solution;
-                output.is_proven_infeasible = cg_output.is_proven_infeasible;
+                algorithm_formatter.update_bound(cg_output.bound);
             }
             if (!cg_output.relaxation_solution_is_feasible) {
                 //std::cout << "no solution" << std::endl;


### PR DESCRIPTION
column_highest_cost is 0 whenever every column has an objective coefficient of 0 (pure feasibility problems), which permanently disabled the dummy-column infeasibility check regardless of how large the dummy coefficient grew. Dropping the 'column_highest_cost > 0' guard fixes this: the threshold already reduces correctly to "dummy coefficient > 0" in that case, since the master LP's optimal basis doesn't depend on the dummy coefficient's magnitude when the real objective is identically 0.

Replace the separate is_proven_infeasible flag with the standard extended-reals convention: the optimal value of an infeasible problem is +inf (minimization) or -inf (maximization), so infeasibility is now signaled by 'bound' reaching that value instead of a dedicated boolean. This propagates for free through the existing new_bound_callback chain already wired through greedy and limited_discrepancy_search, and also now covers the early "fixed columns already violate a row" case in column_generation.cpp, which never set the old flag at all.

Also add Output::bound_string(), since nlohmann::json silently serializes both +inf and -inf to null, which would otherwise make "proven infeasible" indistinguishable from "no bound established yet" in JSON output.